### PR TITLE
Fix link references in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The project consists of the following components:
 ## 🚀 Getting Started <a id="getting-started"></a>
 
 To set up and run ForestGuard locally, please consult the chapters
-[Deployment View](https://github.com/fraunhofer-iml/forest-guard/blob/main/documentation/07-deployment-view.adoc) and
-[Tutorial](https://github.com/fraunhofer-iml/forest-guard/blob/main/documentation/12-tutorial.adoc) in our documentation. These two chapters
+[Deployment View](https://github.com/fraunhofer-iml/forest-guard/blob/main/documentation/04-deployment-view.adoc) and
+[Tutorial](https://github.com/fraunhofer-iml/forest-guard/blob/main/documentation/05-tutorial.adoc) in our documentation. These two chapters
 provide step-by-step instructions to guide you through the process of installing, configuring and running ForestGuard on your local machine.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ The project consists of the following components:
 ## 🚀 Getting Started <a id="getting-started"></a>
 
 To set up and run ForestGuard locally, please consult the chapters
-[Deployment View](https://github.com/fraunhofer-iml/forest-guard/blob/main/documentation/04-deployment-view.adoc) and
-[Tutorial](https://github.com/fraunhofer-iml/forest-guard/blob/main/documentation/05-tutorial.adoc) in our documentation. These two chapters
+[Deployment View](./documentation/04-deployment-view.adoc) and
+[Tutorial](./documentation/05-tutorial.adoc) in our documentation. These two chapters
 provide step-by-step instructions to guide you through the process of installing, configuring and running ForestGuard on your local machine.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/documentation/04-deployment-view.adoc
+++ b/documentation/04-deployment-view.adoc
@@ -122,7 +122,7 @@ http://localhost:4200
 Username: admin
 Password: admin
 
-For detailed instructions on how to use the application, refer to the xref:chapter-tutorial[Tutorial] chapter in this documentation.
+For detailed instructions on how to use the application, refer to the xref:05-tutorial.adoc#chapter-tutorial[Tutorial] chapter in this documentation.
 
 [NOTE]
 ====

--- a/documentation/04-deployment-view.adoc
+++ b/documentation/04-deployment-view.adoc
@@ -119,10 +119,10 @@ http://localhost:4200
 
 2. *Log in* with the default credentials:
 [source,shell]
-Username: admin  
+Username: admin
 Password: admin
 
-For detailed instructions on how to use the application, refer to the <<chapter-tutorial,Tutorial>> chapter in this documentation.
+For detailed instructions on how to use the application, refer to the xref:chapter-tutorial[Tutorial] chapter in this documentation.
 
 [NOTE]
 ====


### PR DESCRIPTION
I tried to follow the instructions to boot up the project on my machine (which worked easily btw), I found some wrong link references.

I am not experienced with ascii doc, but I think this should fix it.